### PR TITLE
Forbid deletion of Scenario in Compass UI if there are existing associated runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,20 @@
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+**/.DS_Store
+**/.env.local
+**/.env.development.local
+**/.env.test.local
+**/.env.production.local
+
 node_modules
 .pnp
 .pnp.js
 **/node_modules
 **/.pnp
 **/.pnp.js
-
-**/.env.local
-**/.env.development.local
-**/.env.test.local
-**/.env.production.local
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
 
 npm-debug.log*
 lerna-debug.log*
@@ -24,6 +25,10 @@ yarn-error.log*
 **/yarn-debug.log*
 **/yarn-error.log*
 
+.idea
+.vscode
+**/.idea
+**/.vscode
 
 dist
 lib

--- a/compass/package.json
+++ b/compass/package.json
@@ -18,7 +18,7 @@
     "start:kyma": "echo 'This component is not ready yet to be served together with Console.'",
     "start:kyma:api": "echo 'This component is not ready yet to be served together with Console.'",
     "build": "npm run buildConfig && ../node_modules/.bin/react-scripts build && ncp 'node_modules/@luigi-project/core' 'public-luigi/luigi-core'",
-    "test": "echo 'Compass unit tests are disabled'",
+    "test": "../node_modules/.bin/react-scripts test",
     "eject": "../node_modules/.bin/react-scripts eject",
     "buildConfig": "../node_modules/.bin/webpack --mode production --config webpack-generateConfig.config",
     "buildConfig:watch": "../node_modules/.bin/webpack -d --config webpack-generateConfig.config --watch"

--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetails.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetails.js
@@ -13,12 +13,16 @@ ScenarioDetails.propTypes = {
 
 export default function ScenarioDetails({ scenarioName }) {
   const [applicationsCount, setApplicationsCount] = useState(0);
+  const [runtimesCount, setRuntimesCount] = useState(0);
 
   return (
     <ScenarioNameContext.Provider value={scenarioName}>
-      <ScenarioDetailsHeader applicationsCount={applicationsCount} />
+      <ScenarioDetailsHeader
+        applicationsCount={applicationsCount}
+        runtimesCount={runtimesCount}
+      />
       <ScenarioApplications updateApplicationsCount={setApplicationsCount} />
-      <ScenarioRuntimes />
+      <ScenarioRuntimes updateRuntimesCount={setRuntimesCount} />
     </ScenarioNameContext.Provider>
   );
 }

--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetailsHeader/ScenarioDetailsHeader.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetailsHeader/ScenarioDetailsHeader.js
@@ -36,7 +36,10 @@ function createNewInputForDeleteScenarioMutation(
   };
 }
 
-export default function ScenarioDetailsHeader({ applicationsCount }) {
+export default function ScenarioDetailsHeader({
+  applicationsCount,
+  runtimesCount,
+}) {
   const scenarioName = useContext(ScenarioNameContext);
 
   const { data: scenariosLabelSchema, error, loading } = useQuery(
@@ -54,7 +57,8 @@ export default function ScenarioDetailsHeader({ applicationsCount }) {
   const canDelete = () => {
     return (
       nonDeletableScenarioNames.includes(scenarioName) ||
-      applicationsCount !== 0
+      applicationsCount !== 0 ||
+      runtimesCount !== 0
     );
   };
 

--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
@@ -19,6 +19,7 @@ export default function ScenarioRuntimes({
   getRuntimesForScenario,
   setRuntimeScenarios,
   deleteRuntimeScenarios,
+  updateRuntimesCount,
 }) {
   const [sendNotification] = useMutation(SEND_NOTIFICATION);
 
@@ -62,6 +63,7 @@ export default function ScenarioRuntimes({
   ];
 
   const assignedRuntimes = getRuntimesForScenario.runtimes.data;
+  updateRuntimesCount(getRuntimesForScenario.runtimes.totalCount);
 
   const extraHeaderContent = (
     <AssignEntityToScenarioModal

--- a/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/test/ScenarioRuntimes.test.js
+++ b/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/test/ScenarioRuntimes.test.js
@@ -19,6 +19,7 @@ describe('ScenarioRuntimes', () => {
         deleteRuntimeScenarios={() => {}}
         setRuntimeScenarios={() => {}}
         sendNotification={() => {}}
+        updateRuntimesCount={() => {}}
       />,
     );
 

--- a/compass/src/components/Scenarios/ScenarioDetails/test/__snapshots__/ScenarioDetails.test.js.snap
+++ b/compass/src/components/Scenarios/ScenarioDetails/test/__snapshots__/ScenarioDetails.test.js.snap
@@ -6,10 +6,13 @@ exports[`ScenarioDetailsHeader Renders with minimal props 1`] = `
 >
   <ScenarioDetailsHeader
     applicationsCount={0}
+    runtimesCount={0}
   />
   <ScenarioApplications
     updateApplicationsCount={[Function]}
   />
-  <fromRenderProps(Apollo(Apollo(Apollo(Apollo(ScenarioRuntimes))))) />
+  <fromRenderProps(Apollo(Apollo(Apollo(Apollo(ScenarioRuntimes)))))
+    updateRuntimesCount={[Function]}
+  />
 </ContextProvider>
 `;


### PR DESCRIPTION
# Overview

This PR fixes the bug where the **Delete** scenario button would be clickable if there are existing runtimes associated with the scenario.

The bug would allow clicking **Delete** which resulted in a failed **updateLabelDefinition** backend request ultimately failing to delete the scenario anyway (but the Compass UI makes it look for a moment as if it was successful, not showing any errors at all).

![image](https://user-images.githubusercontent.com/15074116/97802636-6f484980-1c4d-11eb-9413-e67f1f9071f0.png)