### PR TITLE
Allow auth list to be null

### DIFF
--- a/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
+++ b/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
@@ -41,7 +41,7 @@ const AuthContext = ({ context }) => {
 };
 
 export default function AuthList({ auths }) {
-  if (auths == null) {
+  if (auths === null) {
     auths = [];
   }
 

--- a/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
+++ b/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
@@ -41,7 +41,7 @@ const AuthContext = ({ context }) => {
 };
 
 export default function AuthList({ auths }) {
-  if (auths === null) {
+  if (!auths) {
     auths = [];
   }
 

--- a/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
+++ b/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
@@ -41,9 +41,7 @@ const AuthContext = ({ context }) => {
 };
 
 export default function AuthList({ auths }) {
-  if (!auths) {
-    auths = [];
-  }
+  auths = auths || [];
 
   const headerRenderer = () => ['Context', 'Status', ''];
 

--- a/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
+++ b/compass/src/components/ApiPackages/ApiPackageDetails/AuthList/AuthList.js
@@ -6,7 +6,7 @@ import { Badge } from 'fundamental-react';
 import { GenericList, StatusBadge } from 'react-shared';
 
 AuthList.propTypes = {
-  auths: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+  auths: PropTypes.arrayOf(PropTypes.object.isRequired),
 };
 
 const AuthStatus = ({ timestamp, message, reason, condition }) => {
@@ -41,6 +41,10 @@ const AuthContext = ({ context }) => {
 };
 
 export default function AuthList({ auths }) {
+  if (auths == null) {
+    auths = [];
+  }
+
   const headerRenderer = () => ['Context', 'Status', ''];
 
   const rowRenderer = (auth) => [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- The auth list returned from the gql server can now be nil (because it is a sensitive field), hence we should handle nil responses.
Observed error when rendering application bundles (packages):
![image](https://user-images.githubusercontent.com/9128192/114528272-899d3f00-9c51-11eb-9721-ecda40fcec63.png)
