### PR TITLE
Fix boolean labels representation

### DIFF
--- a/compass/src/components/Shared/MetadataTable/MetadataTable.js
+++ b/compass/src/components/Shared/MetadataTable/MetadataTable.js
@@ -29,7 +29,9 @@ export default function MetadataTable({ labels, ownerType, ignoredLabels }) {
         .map(([key, value]) => ({
           key,
           value:
-            typeof value === 'object' ? JSON.stringify(value, null, 2) : value,
+            typeof value === 'object'
+              ? JSON.stringify(value, null, 2)
+              : value + '',
         }))
     : [];
 


### PR DESCRIPTION
## Description

Currently, Boolean values for labels are not displayed in Compass UI.

Fix casts the value to string in order to unify the representation.