### PR TITLE
Support visualization of OpenAPI V2 and V3 + EDMX specs

### DIFF
--- a/compass/src/components/Api/ApiHelpers.js
+++ b/compass/src/components/Api/ApiHelpers.js
@@ -220,6 +220,6 @@ export function getApiType(api) {
 
 export function getApiDisplayName(api) {
   if (api.spec && api.spec.type) {
-      return api.spec.type.toUpperCase();
+    return api.spec.type.toUpperCase();
   }
 }

--- a/compass/src/components/Api/ApiHelpers.js
+++ b/compass/src/components/Api/ApiHelpers.js
@@ -18,6 +18,11 @@ function isAsyncApi(spec) {
   return spec && !!spec.asyncapi;
 }
 
+function isSwaggerApi(spec) {
+  // according to https://swagger.io/specification/#versions
+  return spec && !!spec.swagger;
+}
+
 function isOpenApi(spec) {
   // according to https://swagger.io/specification/#fixed-fields
   return spec && !!spec.openapi;
@@ -135,7 +140,19 @@ export async function verifyApiFile(file, expectedType) {
     return { error: 'Parse error' };
   }
 
-  if (!isOpenApi(spec) && expectedType === 'OPEN_API') {
+  if (!isSwaggerApi(spec) && !isOpenApi(spec) && expectedType === 'OPEN_API') {
+    return {
+      error:
+        'Supplied spec does not have required "swagger" or "openapi" property',
+    };
+  }
+
+  if (!isSwaggerApi(spec) && expectedType === 'openapi-v2') {
+    return {
+      error: 'Supplied spec does not have required "swagger" property',
+    };
+  }
+  if (!isOpenApi(spec) && expectedType === 'openapi-v3') {
     return {
       error: 'Supplied spec does not have required "openapi" property',
     };
@@ -155,10 +172,17 @@ export function verifyApiInput(apiText, format, apiType) {
     return { error: 'Parse error' };
   }
 
-  if (!isOpenApi(spec) && apiType === 'OPEN_API') {
+  if (!isSwaggerApi(spec) && !isOpenApi(spec) && apiType === 'OPEN_API') {
+    return { error: '"swagger" or "openapi" property is required' };
+  }
+
+  if (!isSwaggerApi(spec) && apiType === 'openapi-v2') {
+    return { error: '"swagger" property is required' };
+  }
+  if (!isOpenApi(spec) && apiType === 'openapi-v3') {
     return { error: '"openapi" property is required' };
   }
-  if (!isOData(spec) && apiType === 'ODATA') {
+  if (!isOData(spec) && (apiType === 'ODATA' || apiType === 'edmx')) {
     return { error: '"edmx:Edmx" property is required' };
   }
 
@@ -181,8 +205,11 @@ export function verifyEventApiInput(eventApiText, format) {
 export function getApiType(api) {
   switch (api.spec && api.spec.type) {
     case 'OPEN_API':
+    case 'openapi-v2':
+    case 'openapi-v3':
       return 'openapi';
     case 'ODATA':
+    case 'edmx':
       return 'odata';
     case 'ASYNC_API':
       return 'asyncapi';
@@ -192,14 +219,7 @@ export function getApiType(api) {
 }
 
 export function getApiDisplayName(api) {
-  switch (api.spec && api.spec.type) {
-    case 'OPEN_API':
-      return 'Open API';
-    case 'ODATA':
-      return 'OData';
-    case 'ASYNC_API':
-      return 'Events API';
-    default:
-      return null;
+  if (api.spec && api.spec.type) {
+      return api.spec.type.toUpperCase();
   }
 }

--- a/compass/src/components/Api/EditApi/EditApi.component.js
+++ b/compass/src/components/Api/EditApi/EditApi.component.js
@@ -142,11 +142,17 @@ function EditApi({
                         width="90px"
                       />
                       <Dropdown
-                        options={{ OPEN_API: 'Open API', ODATA: 'OData' }}
+                        options={{
+                          OPEN_API: 'Open API',
+                          'openapi-v2': 'Open API V2',
+                          'openapi-v3': 'Open API V3',
+                          ODATA: 'OData',
+                          edmx: 'EDMX',
+                        }}
                         selectedOption={apiType}
                         onSelect={setApiType}
                         className="fd-has-margin-x-small"
-                        width="120px"
+                        width="130px"
                       />
                       <Button
                         type="negative"

--- a/compass/src/components/Api/EditApiHeader/EditApiHeader.component.js
+++ b/compass/src/components/Api/EditApiHeader/EditApiHeader.component.js
@@ -47,6 +47,13 @@ export default function EditApiHeader({
     { name: '' },
   ];
 
+  let specType = api.spec.type;
+  let headerDescription;
+  if (specType !== 'ODATA' && specType !== 'OPEN_API' && specType !== 'ASYNC_API') {
+    canSaveChanges = false;
+    headerDescription =  <i>This API/Event definition has been fetched from a remote system in an automated flow. Manual intervention of the API/Event definition is not allowed.</i>
+  }
+
   const actions = (
     <>
       <Button
@@ -65,6 +72,7 @@ export default function EditApiHeader({
   return (
     <PageHeader
       title={api.name}
+      description={headerDescription}
       breadcrumbItems={breadcrumbItems}
       actions={actions}
     >

--- a/compass/src/components/Api/EditApiHeader/EditApiHeader.component.js
+++ b/compass/src/components/Api/EditApiHeader/EditApiHeader.component.js
@@ -47,11 +47,21 @@ export default function EditApiHeader({
     { name: '' },
   ];
 
-  let specType = api.spec.type;
+  const specType = api.spec.type;
   let headerDescription;
-  if (specType !== 'ODATA' && specType !== 'OPEN_API' && specType !== 'ASYNC_API') {
+  if (
+    specType !== 'ODATA' &&
+    specType !== 'OPEN_API' &&
+    specType !== 'ASYNC_API'
+  ) {
     canSaveChanges = false;
-    headerDescription =  <i>This API/Event definition has been fetched from a remote system in an automated flow. Manual intervention of the API/Event definition is not allowed.</i>
+    headerDescription = (
+      <i>
+        This API/Event definition has been fetched from a remote system in an
+        automated flow. Manual intervention of the API/Event definition is not
+        allowed.
+      </i>
+    );
   }
 
   const actions = (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

# Support visualization of OpenAPI V2 and V3 + EDMX specs

**Description**

Changes proposed in this pull request:

- Support visualization of OpenAPI V2 and V3 + EDMX specs
- Forbid modification of API/Event definitions which are fetched as part of ORD Aggregator flow

For the rest of the backend spec types to be supported (ex. RAML or WSDL (soap)), dedicated Custom Render Engines have to be developed in React for each unique spec type.