### PR TITLE
Fix misplaced loader in tenant search

### DIFF
--- a/compass/src/components/TenantSearch/TenantSearch.js
+++ b/compass/src/components/TenantSearch/TenantSearch.js
@@ -117,11 +117,7 @@ export function TenantSearch({ parentPath, token }) {
     <Panel className="fd-has-padding-s tenant-search">
       <SearchInput setFilter={setFilterWithDelay} />
       {error && <p className="fd-has-color-status-3">{error}</p>}
-      {isLoading && (
-        <div className="tenant-search-spinner">
-          <Spinner />
-        </div>
-      )}
+      {isLoading && <Spinner />}
       <TenantList
         fetcher={getTenants}
         pageSize={pageSize}

--- a/compass/src/components/TenantSearch/TenantSearch.scss
+++ b/compass/src/components/TenantSearch/TenantSearch.scss
@@ -1,25 +1,25 @@
 .scrollable-field {
-    height: 22rem;
-    overflow: auto;
+  height: 85vh;
+  overflow: auto;
 }
 
 .tenant-search {
-    height: 26rem;
+  height: 100vh;
 
-    &-spinner {
-        position: absolute;
-        top: 15%;
-        left: 40%;
-        z-index: 9999;
-        text-align: center;
-    }
+  &-spinner {
+    position: absolute;
+    top: 15%;
+    left: 40%;
+    z-index: 9999;
+    text-align: center;
+  }
 
-    .list-group {
-        margin-top: 0 !important;
-    }
-    .list-item {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        cursor: pointer;
-    }
+  .list-group {
+    margin-top: 0 !important;
+  }
+  .list-item {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
**Description**
Currently, the loading spinner inside the tenant search menu is misplaced when opened on bigger screens (tested on 4K monitors). This PR fixes the problem. 

**Changes proposed in this pull request:**

- Remove div with unused class.


