### PR TITLE
Bump dependency in main package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2191,7 +2191,7 @@
     "@kyma-project/generic-documentation": {
       "version": "file:components/generic-documentation",
       "requires": {
-        "@braintree/sanitize-url": "^6.0.0",
+        "@braintree/sanitize-url": "^6.0.1",
         "@kyma-project/dc-async-api-render-engine": "0.3.6",
         "@kyma-project/dc-markdown-render-engine": "0.3.6",
         "@kyma-project/dc-odata-render-engine": "0.3.6",


### PR DESCRIPTION
**Description**
The bumped dependency was in the `components/generic-documentation` component and in #81  only the package.json and package-lock.json there were updated, missing the main `package-lock.json`

Changes proposed in this pull request:

- run npm install to update the main `package-lock.json`

**Related issue(s)**
- #81

