### PR TITLE
Bump alpine image to 3.17.3

### DIFF
--- a/compass/Dockerfile
+++ b/compass/Dockerfile
@@ -25,7 +25,7 @@ ENV CI true
 RUN cd /app/${app_name} && make build
 
 ### Main image ###
-FROM alpine:3.15.6
+FROM alpine:3.17.3
 
 ### Update apk repositories for the latest nginx
 RUN printf "%s%s%s\n" \


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump alpine base image from `3.15.6` to `3.17.3`

**Related issue(s)**
- kyma-incubator/compass#3022
- kyma-incubator/ord-service#92

